### PR TITLE
[FIX] Fa FB position

### DIFF
--- a/frontend/src/components/story/Card/Card.scss
+++ b/frontend/src/components/story/Card/Card.scss
@@ -35,6 +35,7 @@
       .facebook-logo {
         color: white;
         font-size: 24px;
+        transform: translateY(2px);
       }
       &:hover {
         background: $oc-blue-9;


### PR DESCRIPTION
## 문제
현재 대숲 UI Components 중 카드 하나를 살펴보겠습니다.

![image](https://user-images.githubusercontent.com/37534735/56029594-b57d4580-5d55-11e9-8d44-ba850b647ce2.png)

이 컴포넌트에서 페이스북 링크 아이콘이 살짝 위로 치우쳐져 있는 모습이 보입니다.

![image](https://user-images.githubusercontent.com/37534735/56029665-db0a4f00-5d55-11e9-9509-4cc869447602.png)

이는 React Icons 라이브러리 자체의 문제이지만 조금이나마 해결할 수 있는 방법을 드리려고 합니다.

## 해결법
`/frontend/src/components/story/Card/Card.scss` 파일에서 `.facebook-logo` 클래스가 정의된 `35~39 line`의 CSS를 조금 수정하는 방법입니다.

```css
.facebook-logo {
  color: white;
  font-size: 24px;
  transform: translateY(2px); // 추가
}
```

해당 프로퍼티를 추가하고 나면, 어느 정도 중앙에 위치하게 된 페이스북 아이콘을 볼 수 있습니다.

![image](https://user-images.githubusercontent.com/37534735/56029983-aea30280-5d56-11e9-8aa1-4321eb966aa1.png)
![image](https://user-images.githubusercontent.com/37534735/56030007-c24e6900-5d56-11e9-8bf7-192315fd76b2.png)

## 꼬릿말
이 해결법을 담은 풀 리퀘스트를 올립니다.

아무쪼록 도움이 되셨길 바랍니다 :)